### PR TITLE
feature: transfer ownership item acts differently according to card ownership

### DIFF
--- a/app/src/main/java/org/satochip/satodimeapp/Navigation.kt
+++ b/app/src/main/java/org/satochip/satodimeapp/Navigation.kt
@@ -71,8 +71,8 @@ fun Navigation() {
 
     if (sharedViewModel.isAskingForCardOwnership) {
         SatoLog.d(TAG, "Navigation: Card needs ownership!")
-        AcceptOwnershipView(navController, sharedViewModel)
-        return
+        navController.navigate(SatodimeScreen.AcceptOwnershipView.name)
+
     }
 
     NavHost(
@@ -88,6 +88,9 @@ fun Navigation() {
         }
         composable(route = SatodimeScreen.ThirdWelcome.name) {
             ThirdWelcomeView(navController)
+        }
+        composable(route = SatodimeScreen.AcceptOwnershipView.name) {
+            AcceptOwnershipView(navController, sharedViewModel)
         }
 
         // SEAL

--- a/app/src/main/java/org/satochip/satodimeapp/ui/CreateVaultView.kt
+++ b/app/src/main/java/org/satochip/satodimeapp/ui/CreateVaultView.kt
@@ -43,6 +43,7 @@ import androidx.navigation.compose.rememberNavController
 import org.satochip.satodimeapp.R
 import org.satochip.satodimeapp.data.Coin
 import org.satochip.satodimeapp.data.NfcResultCode
+import org.satochip.satodimeapp.data.OwnershipStatus
 import org.satochip.satodimeapp.services.SatoLog
 import org.satochip.satodimeapp.ui.components.BottomButton
 import org.satochip.satodimeapp.ui.components.NfcDialog
@@ -67,6 +68,7 @@ fun CreateVaultView(
     val isReadyToNavigate = remember { mutableStateOf(false) }// for auto navigation to next view
     val selectedCoin = Coin.valueOf(selectedCoinName)
     val scrollState = rememberScrollState()
+    val satodimeUnclaimed = stringResource(R.string.satodimeUnclaimed)
 
     // todo display vault index in view!
 
@@ -140,6 +142,10 @@ fun CreateVaultView(
             Spacer(Modifier.weight(1f))
             BottomButton(
                 onClick = {
+                    if (sharedViewModel.ownershipStatus == OwnershipStatus.Unclaimed) {
+                        Toast.makeText(context, satodimeUnclaimed, Toast.LENGTH_SHORT).show()
+                        return@BottomButton
+                    }
                     // generate entropy based on current time
                     val random = SecureRandom()
                     var entropyBytes = ByteArray(32)

--- a/app/src/main/java/org/satochip/satodimeapp/ui/ExpertModeView.kt
+++ b/app/src/main/java/org/satochip/satodimeapp/ui/ExpertModeView.kt
@@ -1,6 +1,7 @@
 package org.satochip.satodimeapp.ui
 
 import android.app.Activity
+import android.widget.Toast
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -46,6 +47,7 @@ import kotlinx.coroutines.delay
 import org.satochip.satodimeapp.R
 import org.satochip.satodimeapp.data.Coin
 import org.satochip.satodimeapp.data.NfcResultCode
+import org.satochip.satodimeapp.data.OwnershipStatus
 import org.satochip.satodimeapp.services.SatoLog
 import org.satochip.satodimeapp.ui.components.BottomButton
 import org.satochip.satodimeapp.ui.components.NfcDialog
@@ -73,6 +75,7 @@ fun ExpertModeView(
     val focusRequester = remember { FocusRequester() }
     val showNfcDialog = remember { mutableStateOf(false) } // for NfcDialog
     val isReadyToNavigate = remember { mutableStateOf(false) }// for auto navigation to next view
+    val satodimeUnclaimed = stringResource(R.string.satodimeUnclaimed)
 
     Column(
         modifier = Modifier
@@ -170,6 +173,10 @@ fun ExpertModeView(
 //        val pleaseConnectTheCardText = stringResource(R.string.please_connect_the_card)
         BottomButton(
             onClick = {
+                if (sharedViewModel.ownershipStatus == OwnershipStatus.Unclaimed) {
+                    Toast.makeText(context, satodimeUnclaimed, Toast.LENGTH_SHORT).show()
+                    return@BottomButton
+                }
                 // select network
                 var isTestnet = (selectedNetwork == Network.TestNet)
 

--- a/app/src/main/java/org/satochip/satodimeapp/ui/MenuView.kt
+++ b/app/src/main/java/org/satochip/satodimeapp/ui/MenuView.kt
@@ -38,6 +38,7 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
 import androidx.navigation.compose.rememberNavController
 import org.satochip.satodimeapp.R
+import org.satochip.satodimeapp.data.OwnershipStatus
 import org.satochip.satodimeapp.ui.components.InfoDialog
 import org.satochip.satodimeapp.ui.components.shared.HeaderRow
 import org.satochip.satodimeapp.ui.theme.DarkBlue
@@ -110,7 +111,13 @@ fun MenuView(navController: NavController, sharedViewModel: SharedViewModel) {
                     LightGray,
                     R.drawable.users
                 ) {
-                    navController.navigate(SatodimeScreen.TransferOwnershipView.name)
+                    if (sharedViewModel.isCardDataAvailable && sharedViewModel.ownershipStatus == OwnershipStatus.Owner) {
+                        navController.navigate(SatodimeScreen.TransferOwnershipView.name)
+                    } else if (sharedViewModel.ownershipStatus == OwnershipStatus.Unclaimed) {
+                        sharedViewModel.isAskingForCardOwnership = true
+                    } else {
+                        showNoCardScannedDialog.value = true
+                    }
                 }
             }
             Row(
@@ -177,14 +184,6 @@ fun MenuView(navController: NavController, sharedViewModel: SharedViewModel) {
                     )
                 }
             }
-
-//        Divider(
-//            modifier = Modifier
-//                .padding(20.dp)
-//                .height(2.dp)
-//                .width(150.dp),
-//            color = Color.DarkGray,
-//        )
             Card(
                 modifier = Modifier
                     .fillMaxWidth()
@@ -221,13 +220,17 @@ fun MenuView(navController: NavController, sharedViewModel: SharedViewModel) {
         }
     }
 
-    if (showNoCardScannedDialog.value
-        && !sharedViewModel.isCardDataAvailable
-    ) {
+    if (showNoCardScannedDialog.value) {
+        var title = stringResource(id = R.string.cardNeedToBeScannedTitle)
+        var message = stringResource(id = R.string.cardNeedToBeScannedMessage)
+        if (sharedViewModel.ownershipStatus == OwnershipStatus.NotOwner) {
+            title = stringResource(id = R.string.youAreNotTheCardOwner)
+            message = stringResource(id = R.string.nfcUnlockSecretNotFound)
+        }
         InfoDialog(
             openDialogCustom = showNoCardScannedDialog,
-            title = stringResource(R.string.cardNeedToBeScannedTitle),
-            message = stringResource(R.string.cardNeedToBeScannedMessage),
+            title = title,
+            message = message,
             isActionButtonVisible = false,
             buttonTitle = "",
             buttonAction = {},

--- a/app/src/main/java/org/satochip/satodimeapp/ui/ResetWarningView.kt
+++ b/app/src/main/java/org/satochip/satodimeapp/ui/ResetWarningView.kt
@@ -1,7 +1,6 @@
 package org.satochip.satodimeapp.ui
 
 import android.app.Activity
-import android.util.Log
 import android.widget.Toast
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -22,7 +21,6 @@ import androidx.compose.material.Divider
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
@@ -38,9 +36,9 @@ import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
 import androidx.navigation.compose.rememberNavController
-import kotlinx.coroutines.delay
 import org.satochip.satodimeapp.R
 import org.satochip.satodimeapp.data.NfcResultCode
+import org.satochip.satodimeapp.data.OwnershipStatus
 import org.satochip.satodimeapp.services.SatoLog
 import org.satochip.satodimeapp.ui.components.BottomButton
 import org.satochip.satodimeapp.ui.components.EmptyVaultCard
@@ -52,7 +50,6 @@ import org.satochip.satodimeapp.ui.theme.LightGray
 import org.satochip.satodimeapp.ui.theme.SatodimeTheme
 import org.satochip.satodimeapp.util.SatodimeScreen
 import org.satochip.satodimeapp.viewmodels.SharedViewModel
-import kotlin.time.Duration.Companion.seconds
 
 private const val TAG = "ResetWarningView"
 
@@ -63,6 +60,8 @@ fun ResetWarningView(navController: NavController, sharedViewModel: SharedViewMo
     val isBackupConfirmed = remember { mutableStateOf(false) }
     val isReadyToNavigate = remember{ mutableStateOf(false) }// for auto navigation to next view
     val scrollState = rememberScrollState()
+    val satodimeUnclaimed = stringResource(R.string.satodimeUnclaimed)
+
     val vaults = sharedViewModel.cardVaults
 
     RedGradientBackground()
@@ -159,6 +158,10 @@ fun ResetWarningView(navController: NavController, sharedViewModel: SharedViewMo
             val pleaseConfirmBackupText = stringResource(R.string.pleaseConfirmYouHaveMadeBackup)
             BottomButton(
                 onClick = {
+                    if (sharedViewModel.ownershipStatus == OwnershipStatus.Unclaimed) {
+                        Toast.makeText(context, satodimeUnclaimed, Toast.LENGTH_SHORT).show()
+                        return@BottomButton
+                    }
                     // scan card
                     if (isBackupConfirmed.value) {
                         SatoLog.d(

--- a/app/src/main/java/org/satochip/satodimeapp/ui/ShowPrivateKeyView.kt
+++ b/app/src/main/java/org/satochip/satodimeapp/ui/ShowPrivateKeyView.kt
@@ -1,6 +1,7 @@
 package org.satochip.satodimeapp.ui
 
 import android.app.Activity
+import android.widget.Toast
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -45,6 +46,7 @@ import androidx.navigation.compose.rememberNavController
 import kotlinx.coroutines.delay
 import org.satochip.satodimeapp.R
 import org.satochip.satodimeapp.data.NfcResultCode
+import org.satochip.satodimeapp.data.OwnershipStatus
 import org.satochip.satodimeapp.services.SatoLog
 import org.satochip.satodimeapp.ui.components.BottomButton
 import org.satochip.satodimeapp.ui.components.NfcDialog
@@ -75,6 +77,7 @@ fun ShowPrivateKeyView(navController: NavController, sharedViewModel: SharedView
     if (selectedVault > vaultsSize || vaults?.get(selectedVault - 1) == null) return
     val vault = vaults[selectedVault - 1]!!
     val requestedPrivkeyType = remember{ mutableStateOf(RequestedPrivkeyType.NONE) }
+    val satodimeUnclaimed = stringResource(R.string.satodimeUnclaimed)
 
     RedGradientBackground()
     Column(
@@ -98,7 +101,10 @@ fun ShowPrivateKeyView(navController: NavController, sharedViewModel: SharedView
             title = R.string.showPrivateKeyLegacy,
             icon = R.drawable.arrow_right_circle
         ) {
-
+            if (sharedViewModel.ownershipStatus == OwnershipStatus.Unclaimed) {
+                Toast.makeText(context, satodimeUnclaimed, Toast.LENGTH_SHORT).show()
+                return@PrivateKeyItem
+            }
             var privkey = sharedViewModel.cardPrivkeys[selectedVault - 1]
 
             if (privkey == null) {
@@ -126,6 +132,10 @@ fun ShowPrivateKeyView(navController: NavController, sharedViewModel: SharedView
             title = R.string.showPrivateKeyWIF,
             icon = R.drawable.arrow_right_circle
         ) {
+            if (sharedViewModel.ownershipStatus == OwnershipStatus.Unclaimed) {
+                Toast.makeText(context, satodimeUnclaimed, Toast.LENGTH_SHORT).show()
+                return@PrivateKeyItem
+            }
             var privkey = sharedViewModel.cardPrivkeys[selectedVault - 1]
             if (privkey == null) {
                 // recover privkey
@@ -153,6 +163,10 @@ fun ShowPrivateKeyView(navController: NavController, sharedViewModel: SharedView
             title = R.string.showEntropy,
             icon = R.drawable.arrow_right_circle
         ) {
+            if (sharedViewModel.ownershipStatus == OwnershipStatus.Unclaimed) {
+                Toast.makeText(context, satodimeUnclaimed, Toast.LENGTH_SHORT).show()
+                return@PrivateKeyItem
+            }
             var privkey = sharedViewModel.cardPrivkeys[selectedVault - 1]
             if (privkey == null) {
                 // recover privkey

--- a/app/src/main/java/org/satochip/satodimeapp/ui/UnsealWarningView.kt
+++ b/app/src/main/java/org/satochip/satodimeapp/ui/UnsealWarningView.kt
@@ -36,6 +36,7 @@ import androidx.navigation.NavController
 import androidx.navigation.compose.rememberNavController
 import org.satochip.satodimeapp.R
 import org.satochip.satodimeapp.data.NfcResultCode
+import org.satochip.satodimeapp.data.OwnershipStatus
 import org.satochip.satodimeapp.services.SatoLog
 import org.satochip.satodimeapp.ui.components.BottomButton
 import org.satochip.satodimeapp.ui.components.NfcDialog
@@ -59,6 +60,7 @@ fun UnsealWarningView(
     val showNfcDialog = remember { mutableStateOf(false) } // for NfcDialog
     val isReadyToNavigate = remember { mutableStateOf(false) }// for auto navigation to next view
     val scrollState = rememberScrollState()
+    val satodimeUnclaimed = stringResource(R.string.satodimeUnclaimed)
 
     val vaults = sharedViewModel.cardVaults
     val vaultsSize = vaults?.size ?: 0
@@ -137,6 +139,10 @@ fun UnsealWarningView(
             Spacer(Modifier.weight(1f))
             BottomButton(
                 onClick = {
+                    if (sharedViewModel.ownershipStatus == OwnershipStatus.Unclaimed) {
+                        Toast.makeText(context, satodimeUnclaimed, Toast.LENGTH_SHORT).show()
+                        return@BottomButton
+                    }
                     // scan card
                     SatoLog.d(
                         TAG,

--- a/app/src/main/java/org/satochip/satodimeapp/util/Screen.kt
+++ b/app/src/main/java/org/satochip/satodimeapp/util/Screen.kt
@@ -19,6 +19,7 @@ enum class SatodimeScreen {
     MenuView,
     CardInfoView,
     TransferOwnershipView,
+    AcceptOwnershipView,
     SettingsView,
     ShowLogsView,
     AuthenticCardView,

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -76,6 +76,7 @@
     <string name="pleaseConfirmYouHaveMadeBackup">Veuillez confirmer que vous avez fait une sauvegarde</string>
     <string name="vaultSuccessfullyReset">Votre coffre-fort a été réinitialisé</string>
     <string name="actionCancelled">Action annulée</string>
+    <string name="satodimeUnclaimed">Satodime n\'est pas réclamé</string>
     <string name="youCanNowCreateAndSeal">Vous pouvez maintenant créer et sceller un nouveau coffre-fort.</string>
     <string name="takeTheOwnershipTitle">Devenir propriétaire</string>
     <string name="takeTheOwnershipDescription">Pour effectuer des opérations sensibles sur la carte (sceller-desceller-réinitialiser), vous devez être le propriétaire.\n\nCe droit est révocable et transférable à tout moment dans les options de l\'application.\n\nCliquez sur Accepter pour obtenir ce droit.\nou Annuler pour y renoncer.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -54,6 +54,7 @@ To facilitate maintenance, keep same key name whenever possible
     <string name="resettingThisCryptoVaultWill">Reset this vault will completely and irrevocably delete the corresponding private key from your card.</string>
     <string name="resetBtn">Reset</string>
     <string name="actionCancelled">Action cancelled</string>
+    <string name="satodimeUnclaimed">Satodime is unclaimed</string>
     <!--    <string name="reset_cap">Reset</string>-->
 <!--    <string name="this_vault_will_completely_and_irrevocably">" this vault will completely and irrevocably "</string>-->
 <!--    <string name="delete">delete</string>-->


### PR DESCRIPTION
Implemented:

- If card is unclaimed now it shows a toast notifying that it is unclaimed when trying to seal, unseal or delete a vault. Before it tried to do their respective actions and then change the card status to not owner in app, which is unnecessary.
- Button in menu "Transfer ownership" would open a page to transfer ownership every time, even when no card was scanned before. New logic now shows pop up message when card is not scanned or when user is not the owner of the satodime card(since there is no need to try to transfer ownership), but if card is unclaimed we would be routed to a screen to claim ownership, and if we are already owner we have the usual screen that allows us to transfer ownership.
